### PR TITLE
Update vulnerable Ruby dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ GEM
     coffee-script-source (1.12.2)
     colorator (1.1.0)
     commonmarker (0.23.12)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     csv (3.3.5)
     dnsruby (1.73.1)
@@ -40,11 +40,11 @@ GEM
       logger
     eventmachine (1.2.7)
     execjs (2.10.1)
-    faraday (2.14.1)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.4)
       net-http (~> 0.5)
     ffi (1.17.4)
     forwardable-extended (2.6.0)
@@ -217,7 +217,7 @@ GEM
       gemoji (>= 3, < 5)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
-    json (2.19.5)
+    json (2.21.1)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -239,7 +239,7 @@ GEM
       prism (~> 1.5)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    nokogiri (1.19.3)
+    nokogiri (1.19.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     octokit (4.25.1)


### PR DESCRIPTION
## What changed

Updated the locked Ruby dependencies that currently trigger Dependabot alerts:

- `concurrent-ruby` 1.3.6 → 1.3.7
- `faraday` 2.14.1 → 2.14.3
- `nokogiri` 1.19.3 → 1.19.4
- compatible transitive updates for `faraday-net_http` and `json`

## Why

The previous lockfile versions are affected by 13 open Dependabot alerts (2 high, 1 moderate, and 10 low). The patched versions meet the advisory remediation thresholds.

## Impact

This is a lockfile-only change. It retains the existing `github-pages` dependency set while removing the known vulnerable versions.

## Validation

- `bundle check`
- loaded all three patched gems and verified their runtime versions
- `bundle exec jekyll build --destination /private/tmp/codex-telotortium-site`
- `git diff --check`
